### PR TITLE
fix: updated migration script typo

### DIFF
--- a/migrations/v1_setup_tables_and_enums.sql
+++ b/migrations/v1_setup_tables_and_enums.sql
@@ -38,7 +38,7 @@ CREATE TABLE "organisationalUnitAssets" (
 
 CREATE TABLE "trades" (
   "tradeId" uuid PRIMARY KEY,
-  "assetId" uuid UNIQUE,
+  "assetTypeId" uuid UNIQUE,
   "organisationalUnitId" uuid UNIQUE,
   "tradeType" tradeType,
   "quantity" float,


### PR DESCRIPTION
Typo in the script, meant to be "assetTypeId" but instead was "assetId"